### PR TITLE
Feat/linux support

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -4,15 +4,15 @@ This document captures the goals, architecture, and working practices for this r
 
 ## Scope & Goals
 
-- Deliver a clean, reproducible macOS developer environment using Nix Flakes + Home Manager.
+- Deliver a clean, reproducible macOS and Linux developer environment using Nix Flakes + Home Manager.
 - Prioritize simplicity, stability, and maintainability over breadth of options.
 - Keep the surface area focused: Ghostty (terminal) + Zsh (shell) + Neovim (editor) + essential CLI tools.
 - Minimize surprises: default behaviors should be sane, with clear opt‑in for extras.
 
 ## Platform Targets
 
-- macOS only: `x86_64-darwin` and `aarch64-darwin`.
-- Linux and other platforms are out of scope unless explicitly reintroduced later.
+- macOS: `x86_64-darwin` and `aarch64-darwin`.
+- Linux: `x86_64-linux` and `aarch64-linux`.
 
 ## Architecture Overview
 
@@ -54,17 +54,17 @@ This document captures the goals, architecture, and working practices for this r
 
 ## External Dependencies
 
-- Git: required before running the installer (CLT or Homebrew Git).
-- Homebrew or Ghostty: installer requires one of these present (either brew to install Ghostty, or Ghostty already installed).
+- Git: required before running the installer (install via your distro on Linux, CLT/Homebrew on macOS).
+- Ghostty is optional (recommended). On macOS it may be installed via Homebrew; on Linux use your distro or Nix. The installer no longer requires Homebrew.
 
 ## Installation Model
 
 - Single command installer: `scripts/install.sh`
-  - Validates prerequisites (sudo, git, brew or ghostty).
-  - Installs Nix via official script if missing.
+  - Validates prerequisites (sudo, git).
+  - Installs Nix via official script if missing (Linux + macOS).
   - Ensures `/etc/nix/nix.conf` enables `flakes nix-command`.
-  - Optionally installs Ghostty via Homebrew (if brew available).
-  - Applies Home Manager flake `.#gentleman` and sets HM Zsh as default shell.
+  - macOS: optionally installs Ghostty via Homebrew when available.
+  - Applies Home Manager flake for the detected platform/arch and sets HM Zsh as default shell.
 
 ## Future: Custom Install Mode
 
@@ -111,10 +111,24 @@ This document captures the goals, architecture, and working practices for this r
 
 ## Validation Checklist (for releases)
 
-- Fresh macOS (Intel/ARM) with Git + Homebrew or Ghostty present.
+- Fresh macOS (Intel/ARM) with Git present and optionally Homebrew.
+- Fresh Linux (Intel/ARM) with Git present.
 - Run installer once; ensure:
-  - Nix is installed and daemon profile sourced.
+  - Nix is installed and the profile is sourced in the current shell.
   - `/etc/nix/nix.conf` includes experimental features.
-  - Ghostty installed (via brew) or preinstalled.
-  - `home-manager switch` succeeds; Zsh set as default.
-  - New terminal session picks up configuration (PATH, Starship, Neovim).
+  - Ghostty availability verified or install separately (Homebrew on macOS; distro/Nix on Linux).
+  - Home Manager switch succeeds; Zsh set as default shell.
+  - New terminal session picks up configuration (PATH, Starship, Neovim). 
+
+## Linux Migration Work Log
+
+- Completed
+  - Installer: add Linux support (ARM/x86), nix.conf edits portable, daemon reload best-effort, `nix run home-manager` path, Linux-safe shell switching.
+  - Flake: add `x86_64-linux`/`aarch64-linux` targets and homeConfigurations, per-platform Android SDK path, Linux clipboard tools.
+  - Neovide: enable on Linux and set XDG config; add Linux copy/paste keybinds using Ctrl+Shift with `unnamedplus`.
+  - Ghostty: add Linux-friendly copy/paste keybinds (Ctrl+Shift+C/V).
+
+- Next
+  - Validate on a fresh Linux VM (Wayland/X11) and confirm clipboard behavior with `xclip` vs `wl-clipboard`.
+  - Review zsh init for Linux-only path tweaks and reduce Homebrew logic under Linux.
+  - Optional: package Ghostty via Nix on Linux (or distro-specific instructions).

--- a/PLAN.md
+++ b/PLAN.md
@@ -129,6 +129,7 @@ This document captures the goals, architecture, and working practices for this r
   - Neovide: enable on Linux and set XDG config; add Linux copy/paste keybinds using Ctrl+Shift with `unnamedplus`.
   - Ghostty: add Linux-friendly copy/paste keybinds (Ctrl+Shift+C/V).
   - Linux: add `ghostty` to `home.packages` so it’s installed via Nix; after HM switch, source HM session vars and prepend HM bin to PATH in installer so new binaries are usable immediately.
+  - Bash support: add `bash.nix` module (loads hm-session-vars, starship, zoxide, atuin, carapace). Installer now preserves current login shell (bash or zsh) by switching to the HM-managed equivalent.
 
 - Next
   - Validate on a fresh Linux VM (Wayland/X11) and confirm clipboard behavior with `xclip` vs `wl-clipboard`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -128,6 +128,7 @@ This document captures the goals, architecture, and working practices for this r
   - Flake: add `x86_64-linux`/`aarch64-linux` targets and homeConfigurations, per-platform Android SDK path, Linux clipboard tools.
   - Neovide: enable on Linux and set XDG config; add Linux copy/paste keybinds using Ctrl+Shift with `unnamedplus`.
   - Ghostty: add Linux-friendly copy/paste keybinds (Ctrl+Shift+C/V).
+  - Linux: add `ghostty` to `home.packages` so it’s installed via Nix; after HM switch, source HM session vars and prepend HM bin to PATH in installer so new binaries are usable immediately.
 
 - Next
   - Validate on a fresh Linux VM (Wayland/X11) and confirm clipboard behavior with `xclip` vs `wl-clipboard`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -124,6 +124,7 @@ This document captures the goals, architecture, and working practices for this r
 
 - Completed
   - Installer: add Linux support (ARM/x86), nix.conf edits portable, daemon reload best-effort, `nix run home-manager` path, Linux-safe shell switching.
+  - Installer: ensure Nix loads via `$HOME/.nix-profile/etc/profile.d/nix.sh` and `$HOME/.nix-profile/bin` added to PATH so `home-manager` is discoverable.
   - Flake: add `x86_64-linux`/`aarch64-linux` targets and homeConfigurations, per-platform Android SDK path, Linux clipboard tools.
   - Neovide: enable on Linux and set XDG config; add Linux copy/paste keybinds using Ctrl+Shift with `unnamedplus`.
   - Ghostty: add Linux-friendly copy/paste keybinds (Ctrl+Shift+C/V).

--- a/bash.nix
+++ b/bash.nix
@@ -13,7 +13,7 @@
         if (set -o | grep -q 'nounset[[:space:]]*on'); then _HM_NOUNSET_WAS_ON=1; set +u; fi
         unset __HM_SESS_VARS_SOURCED
         . "$HOME/.local/state/nix/profiles/home-manager/home-path/etc/profile.d/hm-session-vars.sh"
-        if [ -n "${_HM_NOUNSET_WAS_ON-}" ]; then set -u; unset _HM_NOUNSET_WAS_ON; fi
+        if [ -n "\${_HM_NOUNSET_WAS_ON-}" ]; then set -u; unset _HM_NOUNSET_WAS_ON; fi
       fi
       # PATH safety
       export PATH="$HOME/.local/state/nix/profiles/home-manager/home-path/bin:$HOME/.nix-profile/bin:$PATH"
@@ -27,7 +27,7 @@
         if (set -o | grep -q 'nounset[[:space:]]*on'); then _HM_NOUNSET_WAS_ON=1; set +u; fi
         unset __HM_SESS_VARS_SOURCED
         . "$HOME/.local/state/nix/profiles/home-manager/home-path/etc/profile.d/hm-session-vars.sh"
-        if [ -n "${_HM_NOUNSET_WAS_ON-}" ]; then set -u; unset _HM_NOUNSET_WAS_ON; fi
+        if [ -n "\${_HM_NOUNSET_WAS_ON-}" ]; then set -u; unset _HM_NOUNSET_WAS_ON; fi
       fi
 
       # Prepend Home Manager profile bin and user nix-profile bin to PATH

--- a/bash.nix
+++ b/bash.nix
@@ -4,6 +4,17 @@
     enable = true;
     enableCompletion = true;
 
+    # Ensure login shells also get sane environment even if system files are stale
+    profileExtra = ''
+      # Prefer Home Manager session variables from home-path when available
+      if [ -f "$HOME/.local/state/nix/profiles/home-manager/home-path/etc/profile.d/hm-session-vars.sh" ]; then
+        unset __HM_SESS_VARS_SOURCED
+        . "$HOME/.local/state/nix/profiles/home-manager/home-path/etc/profile.d/hm-session-vars.sh"
+      fi
+      # PATH safety
+      export PATH="$HOME/.local/state/nix/profiles/home-manager/home-path/bin:$HOME/.nix-profile/bin:$PATH"
+    '';
+
     # Interactive shell setup for Bash
     initExtra = ''
       # Ensure Home Manager session variables are loaded
@@ -34,4 +45,3 @@
     '';
   };
 }
-

--- a/bash.nix
+++ b/bash.nix
@@ -53,6 +53,8 @@
       ${lib.optionalString pkgs.stdenv.isLinux ''
       # Ghostty wrapper for buggy EGL on some Linux VMs
       alias ghostty='GSK_RENDERER=cairo LIBGL_ALWAYS_SOFTWARE=1 ${pkgs.ghostty}/bin/ghostty'
+      # Neovide: prefer software GL and X11 on Linux VMs
+      alias neovide='LIBGL_ALWAYS_SOFTWARE=1 MESA_LOADER_DRIVER_OVERRIDE=llvmpipe WINIT_UNIX_BACKEND=x11 ${pkgs.neovide}/bin/neovide'
       ''}
     '';
   };

--- a/bash.nix
+++ b/bash.nix
@@ -1,0 +1,37 @@
+{ pkgs, lib, ... }:
+{
+  programs.bash = {
+    enable = true;
+    enableCompletion = true;
+
+    # Interactive shell setup for Bash
+    initExtra = ''
+      # Ensure Home Manager session variables are loaded
+      if [ -f "$HOME/.local/state/nix/profiles/home-manager/home-path/etc/profile.d/hm-session-vars.sh" ]; then
+        unset __HM_SESS_VARS_SOURCED
+        . "$HOME/.local/state/nix/profiles/home-manager/home-path/etc/profile.d/hm-session-vars.sh"
+      fi
+
+      # Prepend Home Manager profile bin and user nix-profile bin to PATH
+      export PATH="$HOME/.local/state/nix/profiles/home-manager/home-path/bin:$HOME/.nix-profile/bin:$PATH"
+
+      # Completions/Tools
+      # Carapace completions for bash (safe if not installed)
+      if command -v carapace >/dev/null 2>&1; then
+        source <(carapace _carapace)
+      fi
+
+      # Initialize common tools
+      command -v zoxide >/dev/null 2>&1 && eval "$(zoxide init bash)"
+      command -v atuin >/dev/null 2>&1 && eval "$(atuin init bash)"
+      command -v starship >/dev/null 2>&1 && eval "$(starship init bash)"
+
+      # Helpful aliases (aligned with zsh config)
+      alias o=oil
+      alias of=oil-float
+      alias 'oo=oil .'
+      alias oz=oil-zed
+    '';
+  };
+}
+

--- a/bash.nix
+++ b/bash.nix
@@ -13,7 +13,7 @@
         if (set -o | grep -q 'nounset[[:space:]]*on'); then _HM_NOUNSET_WAS_ON=1; set +u; fi
         unset __HM_SESS_VARS_SOURCED
         . "$HOME/.local/state/nix/profiles/home-manager/home-path/etc/profile.d/hm-session-vars.sh"
-        if [ -n "\${_HM_NOUNSET_WAS_ON-}" ]; then set -u; unset _HM_NOUNSET_WAS_ON; fi
+        if [ -n "''${_HM_NOUNSET_WAS_ON-}" ]; then set -u; unset _HM_NOUNSET_WAS_ON; fi
       fi
       # PATH safety
       export PATH="$HOME/.local/state/nix/profiles/home-manager/home-path/bin:$HOME/.nix-profile/bin:$PATH"
@@ -27,7 +27,7 @@
         if (set -o | grep -q 'nounset[[:space:]]*on'); then _HM_NOUNSET_WAS_ON=1; set +u; fi
         unset __HM_SESS_VARS_SOURCED
         . "$HOME/.local/state/nix/profiles/home-manager/home-path/etc/profile.d/hm-session-vars.sh"
-        if [ -n "\${_HM_NOUNSET_WAS_ON-}" ]; then set -u; unset _HM_NOUNSET_WAS_ON; fi
+        if [ -n "''${_HM_NOUNSET_WAS_ON-}" ]; then set -u; unset _HM_NOUNSET_WAS_ON; fi
       fi
 
       # Prepend Home Manager profile bin and user nix-profile bin to PATH

--- a/bash.nix
+++ b/bash.nix
@@ -49,6 +49,11 @@
       alias of=oil-float
       alias 'oo=oil .'
       alias oz=oil-zed
+
+      ${lib.optionalString pkgs.stdenv.isLinux ''
+      # Ghostty wrapper for buggy EGL on some Linux VMs
+      alias ghostty='GSK_RENDERER=cairo LIBGL_ALWAYS_SOFTWARE=1 ${pkgs.ghostty}/bin/ghostty'
+      ''}
     '';
   };
 }

--- a/bash.nix
+++ b/bash.nix
@@ -8,8 +8,12 @@
     profileExtra = ''
       # Prefer Home Manager session variables from home-path when available
       if [ -f "$HOME/.local/state/nix/profiles/home-manager/home-path/etc/profile.d/hm-session-vars.sh" ]; then
+        # Make sourcing tolerant to `set -u` (nounset)
+        _HM_NOUNSET_WAS_ON=
+        if (set -o | grep -q 'nounset[[:space:]]*on'); then _HM_NOUNSET_WAS_ON=1; set +u; fi
         unset __HM_SESS_VARS_SOURCED
         . "$HOME/.local/state/nix/profiles/home-manager/home-path/etc/profile.d/hm-session-vars.sh"
+        if [ -n "${_HM_NOUNSET_WAS_ON-}" ]; then set -u; unset _HM_NOUNSET_WAS_ON; fi
       fi
       # PATH safety
       export PATH="$HOME/.local/state/nix/profiles/home-manager/home-path/bin:$HOME/.nix-profile/bin:$PATH"
@@ -17,10 +21,13 @@
 
     # Interactive shell setup for Bash
     initExtra = ''
-      # Ensure Home Manager session variables are loaded
+      # Ensure Home Manager session variables are loaded (tolerate `set -u`)
       if [ -f "$HOME/.local/state/nix/profiles/home-manager/home-path/etc/profile.d/hm-session-vars.sh" ]; then
+        _HM_NOUNSET_WAS_ON=
+        if (set -o | grep -q 'nounset[[:space:]]*on'); then _HM_NOUNSET_WAS_ON=1; set +u; fi
         unset __HM_SESS_VARS_SOURCED
         . "$HOME/.local/state/nix/profiles/home-manager/home-path/etc/profile.d/hm-session-vars.sh"
+        if [ -n "${_HM_NOUNSET_WAS_ON-}" ]; then set -u; unset _HM_NOUNSET_WAS_ON; fi
       fi
 
       # Prepend Home Manager profile bin and user nix-profile bin to PATH

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
         ./starship.nix  # Starship prompt configuration
         ./nvim.nix  # Neovim configuration
         ./neovide.nix  # Neovide GUI configuration
+        ./bash.nix  # Bash configuration
         ./zsh.nix  # Zsh configuration
         ./oil-scripts.nix  # Oil.nvim scripts configuration
         ./opencode.nix  # OpenCode AI assistant configuration

--- a/flake.nix
+++ b/flake.nix
@@ -115,13 +115,25 @@
                 REPO_DIR="$HOME/Gentleman.Dots"
                 if [ -d "$REPO_DIR/.git" ]; then
                   echo "[flake] Updating inputs in $REPO_DIR"
-                  (cd "$REPO_DIR" && nix flake update) || true
+                  # Ensure git is available to nix while updating inputs
+                  export PATH="${pkgs.git}/bin:$PATH"
+                  if command -v nix >/dev/null 2>&1 && command -v git >/dev/null 2>&1; then
+                    (cd "$REPO_DIR" && nix flake update) || true
+                  else
+                    echo "[flake] Skipping update (nix or git not available)"
+                  fi
                 fi
               '';
               # Tmux and other terminals are intentionally not managed; only Ghostty + Zsh
 
               # Allow unfree packages
               nixpkgs.config.allowUnfree = true;
+
+              # Tweak Nix user settings
+              nix.settings = {
+                # Avoid small default buffer warnings during large downloads
+                download-buffer-size = 134217728; # 128 MiB
+              };
             }
           ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,9 @@
                 # Avoid small default buffer warnings during large downloads
                 download-buffer-size = 134217728; # 128 MiB
               };
+
+              # Required when using nix.settings via Home Manager
+              nix.package = pkgs.nix;
             }
           ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
                 nerd-fonts.iosevka-term
               ]
               # Extra helpers per-platform
-              ++ lib.optionals isLinux [ xclip wl-clipboard ]
+              ++ lib.optionals isLinux [ xclip wl-clipboard ghostty ]
               ++ [ unstablePkgs.nixd ];
 
               home.sessionVariables = {

--- a/ghostty.nix
+++ b/ghostty.nix
@@ -3,6 +3,18 @@ let
   sourceDir = ./ghostty;
 in
 {
+  # On Linux VMs/drivers, GTK4 + OpenGL can crash. Provide a wrapper that
+  # forces software rendering for Ghostty to avoid EGL issues.
+  home.packages = lib.optionals pkgs.stdenv.isLinux [
+    (pkgs.writeShellScriptBin "ghostty" ''
+      #!/usr/bin/env bash
+      export GSK_RENDERER="${GSK_RENDERER:-cairo}"
+      # Fallback to software GL if drivers are incomplete
+      export LIBGL_ALWAYS_SOFTWARE="${LIBGL_ALWAYS_SOFTWARE:-1}"
+      exec ${pkgs.ghostty}/bin/ghostty "$@"
+    '')
+  ];
+
   # Single source of truth: XDG path
   home.file.".config/ghostty" = {
     source = sourceDir;

--- a/ghostty.nix
+++ b/ghostty.nix
@@ -3,18 +3,6 @@ let
   sourceDir = ./ghostty;
 in
 {
-  # On Linux VMs/drivers, GTK4 + OpenGL can crash. Provide a wrapper that
-  # forces software rendering for Ghostty to avoid EGL issues.
-  home.packages = lib.optionals pkgs.stdenv.isLinux [
-    (pkgs.writeShellScriptBin "ghostty" ''
-      #!/usr/bin/env bash
-      export GSK_RENDERER="${GSK_RENDERER:-cairo}"
-      # Fallback to software GL if drivers are incomplete
-      export LIBGL_ALWAYS_SOFTWARE="${LIBGL_ALWAYS_SOFTWARE:-1}"
-      exec ${pkgs.ghostty}/bin/ghostty "$@"
-    '')
-  ];
-
   # Single source of truth: XDG path
   home.file.".config/ghostty" = {
     source = sourceDir;

--- a/ghostty.nix
+++ b/ghostty.nix
@@ -3,16 +3,8 @@ let
   sourceDir = ./ghostty;
 in
 {
-  # Linux: wrap ghostty to force software rendering to avoid EGL issues on VMs
+  # Linux: provide a 'ghostty-soft' helper to force software rendering
   home.packages = lib.optionals pkgs.stdenv.isLinux [
-    (pkgs.writeShellScriptBin "ghostty" ''
-      #!/usr/bin/env bash
-      # Prefer software rendering for GTK4 in VM/driver-limited environments
-      export GSK_RENDERER="''${GSK_RENDERER:-cairo}"
-      export LIBGL_ALWAYS_SOFTWARE="''${LIBGL_ALWAYS_SOFTWARE:-1}"
-      export MESA_LOADER_DRIVER_OVERRIDE="''${MESA_LOADER_DRIVER_OVERRIDE:-llvmpipe}"
-      exec ${pkgs.ghostty}/bin/ghostty "$@"
-    '')
     (pkgs.writeShellScriptBin "ghostty-soft" ''
       #!/usr/bin/env bash
       export GSK_RENDERER=cairo

--- a/ghostty/config
+++ b/ghostty/config
@@ -67,6 +67,10 @@ keybind = alt+l=goto_split:right
 # Miscellaneous
 keybind = cmd+k=clear_screen
 
+# Linux-friendly copy/paste (works cross-platform, harmless on macOS)
+keybind = ctrl+shift+c=copy_to_clipboard
+keybind = ctrl+shift+v=paste_from_clipboard
+
 # Use it by writing 'nvim' first and then the keybinding to open the file with nvim
 keybind = alt+s=write_screen_file:paste
 palette = 0=#06080f

--- a/neovide.nix
+++ b/neovide.nix
@@ -5,34 +5,36 @@ let
 in
 {
   # Install Neovide and provide a portable "svim" launcher on macOS and Linux
-  home.packages = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux)
-    ([
-      pkgSet.neovide
-      (pkgs.writeShellScriptBin "svim" ''
-        #!/usr/bin/env bash
-        # On Linux, prefer software GL and X11 for compatibility
-        if [ "$(uname -s)" = "Linux" ]; then
-          export LIBGL_ALWAYS_SOFTWARE="''${LIBGL_ALWAYS_SOFTWARE:-1}"
-          export MESA_LOADER_DRIVER_OVERRIDE="''${MESA_LOADER_DRIVER_OVERRIDE:-llvmpipe}"
-          if [ -n "''${DISPLAY-}" ]; then
-            export WINIT_UNIX_BACKEND="''${WINIT_UNIX_BACKEND:-x11}"
+  home.packages =
+    (if pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux then
+      ([
+        pkgSet.neovide
+        (pkgs.writeShellScriptBin "svim" ''
+          #!/usr/bin/env bash
+          # On Linux, prefer software GL and X11 for compatibility
+          if [ "$(uname -s)" = "Linux" ]; then
+            export LIBGL_ALWAYS_SOFTWARE="''${LIBGL_ALWAYS_SOFTWARE:-1}"
+            export MESA_LOADER_DRIVER_OVERRIDE="''${MESA_LOADER_DRIVER_OVERRIDE:-llvmpipe}"
+            if [ -n "''${DISPLAY-}" ]; then
+              export WINIT_UNIX_BACKEND="''${WINIT_UNIX_BACKEND:-x11}"
+            fi
           fi
-        fi
-        if [ $# -eq 0 ]; then
-          exec ${pkgSet.neovide}/bin/neovide --fork
-        else
-          exec ${pkgSet.neovide}/bin/neovide --fork "$@"
-        fi
-      '')
-    ] ++ lib.optionals pkgs.stdenv.isLinux [
-      (pkgs.writeShellScriptBin "neovide-soft" ''
-        #!/usr/bin/env bash
-        export LIBGL_ALWAYS_SOFTWARE=1
-        export MESA_LOADER_DRIVER_OVERRIDE=llvmpipe
-        export WINIT_UNIX_BACKEND=x11
-        exec ${pkgSet.neovide}/bin/neovide "$@"
-      '')
-    ]);
+          if [ $# -eq 0 ]; then
+            exec ${pkgSet.neovide}/bin/neovide --fork
+          else
+            exec ${pkgSet.neovide}/bin/neovide --fork "$@"
+          fi
+        '')
+      ] ++ (if pkgs.stdenv.isLinux then [
+        (pkgs.writeShellScriptBin "neovide-soft" ''
+          #!/usr/bin/env bash
+          export LIBGL_ALWAYS_SOFTWARE=1
+          export MESA_LOADER_DRIVER_OVERRIDE=llvmpipe
+          export WINIT_UNIX_BACKEND=x11
+          exec ${pkgSet.neovide}/bin/neovide "$@"
+        '')
+      ] else []))
+    else [];
 
   # Neovide config (XDG path)
   home.file.".config/neovide/config.toml" = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux) {

--- a/neovide.nix
+++ b/neovide.nix
@@ -15,15 +15,15 @@ in
     force = true;
   };
 
-  # zsh function to launch Neovide as "svim"
-  programs.zsh.initExtra = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux) ''
-    svim() {
+  # Provide a cross-shell launcher "svim" without touching deprecated zsh.initExtra
+  home.packages = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux) [
+    (pkgs.writeShellScriptBin "svim" ''
+      #!/usr/bin/env bash
       if [ $# -eq 0 ]; then
-        neovide --fork
+        exec neovide --fork
       else
-        neovide --fork "$@"
+        exec neovide --fork "$@"
       fi
-      exit
-    }
-  '';
+    '')
+  ];
 }

--- a/neovide.nix
+++ b/neovide.nix
@@ -13,7 +13,7 @@ in
       # Prefer software rendering in VMs; winit prefers X11 for broader compat
       export LIBGL_ALWAYS_SOFTWARE="''${LIBGL_ALWAYS_SOFTWARE:-1}"
       export MESA_LOADER_DRIVER_OVERRIDE="''${MESA_LOADER_DRIVER_OVERRIDE:-llvmpipe}"
-      if [ -n "${DISPLAY-}" ]; then
+      if [ -n "''${DISPLAY-}" ]; then
         export WINIT_UNIX_BACKEND="''${WINIT_UNIX_BACKEND:-x11}"
       fi
       exec ${pkgSet.neovide}/bin/neovide "$@"

--- a/neovide.nix
+++ b/neovide.nix
@@ -4,11 +4,11 @@ let
   pkgSet = if unstablePkgs == null then pkgs else unstablePkgs;
 in
 {
-  # Install Neovide on macOS only
-  home.packages = lib.mkIf pkgs.stdenv.isDarwin [ pkgSet.neovide ];
+  # Install Neovide on macOS and Linux
+  home.packages = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux) [ pkgSet.neovide ];
 
-  # Neovide config (macOS/Linux XDG path)
-  home.file.".config/neovide/config.toml" = lib.mkIf pkgs.stdenv.isDarwin {
+  # Neovide config (XDG path)
+  home.file.".config/neovide/config.toml" = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux) {
     text = ''
       frame = "none"
     '';
@@ -16,7 +16,7 @@ in
   };
 
   # zsh function to launch Neovide as "svim"
-  programs.zsh.initExtra = lib.mkIf pkgs.stdenv.isDarwin ''
+  programs.zsh.initExtra = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux) ''
     svim() {
       if [ $# -eq 0 ]; then
         neovide --fork

--- a/neovide.nix
+++ b/neovide.nix
@@ -7,6 +7,25 @@ in
   # Install Neovide and provide a portable "svim" launcher on macOS and Linux
   home.packages = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux) [
     pkgSet.neovide
+    # Linux: override neovide with a wrapper that forces software GL and X11
+    (lib.optional pkgs.stdenv.isLinux (pkgs.writeShellScriptBin "neovide" ''
+      #!/usr/bin/env bash
+      # Prefer software rendering in VMs; winit prefers X11 for broader compat
+      export LIBGL_ALWAYS_SOFTWARE="''${LIBGL_ALWAYS_SOFTWARE:-1}"
+      export MESA_LOADER_DRIVER_OVERRIDE="''${MESA_LOADER_DRIVER_OVERRIDE:-llvmpipe}"
+      if [ -n "${DISPLAY-}" ]; then
+        export WINIT_UNIX_BACKEND="''${WINIT_UNIX_BACKEND:-x11}"
+      fi
+      exec ${pkgSet.neovide}/bin/neovide "$@"
+    ''))
+    # Convenience helper
+    (lib.optional pkgs.stdenv.isLinux (pkgs.writeShellScriptBin "neovide-soft" ''
+      #!/usr/bin/env bash
+      export LIBGL_ALWAYS_SOFTWARE=1
+      export MESA_LOADER_DRIVER_OVERRIDE=llvmpipe
+      export WINIT_UNIX_BACKEND=x11
+      exec ${pkgSet.neovide}/bin/neovide "$@"
+    ''))
     (pkgs.writeShellScriptBin "svim" ''
       #!/usr/bin/env bash
       if [ $# -eq 0 ]; then

--- a/neovide.nix
+++ b/neovide.nix
@@ -34,7 +34,7 @@ in
           exec ${pkgSet.neovide}/bin/neovide "$@"
         '')
       ] else []))
-    else [];
+    else []);
 
   # Neovide config (XDG path)
   home.file.".config/neovide/config.toml" = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux) {

--- a/neovide.nix
+++ b/neovide.nix
@@ -4,19 +4,9 @@ let
   pkgSet = if unstablePkgs == null then pkgs else unstablePkgs;
 in
 {
-  # Install Neovide on macOS and Linux
-  home.packages = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux) [ pkgSet.neovide ];
-
-  # Neovide config (XDG path)
-  home.file.".config/neovide/config.toml" = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux) {
-    text = ''
-      frame = "none"
-    '';
-    force = true;
-  };
-
-  # Provide a cross-shell launcher "svim" without touching deprecated zsh.initExtra
+  # Install Neovide and provide a portable "svim" launcher on macOS and Linux
   home.packages = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux) [
+    pkgSet.neovide
     (pkgs.writeShellScriptBin "svim" ''
       #!/usr/bin/env bash
       if [ $# -eq 0 ]; then
@@ -26,4 +16,12 @@ in
       fi
     '')
   ];
+
+  # Neovide config (XDG path)
+  home.file.".config/neovide/config.toml" = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux) {
+    text = ''
+      frame = "none"
+    '';
+    force = true;
+  };
 }

--- a/neovide.nix
+++ b/neovide.nix
@@ -5,36 +5,34 @@ let
 in
 {
   # Install Neovide and provide a portable "svim" launcher on macOS and Linux
-  home.packages = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux) [
-    pkgSet.neovide
-    # Linux: override neovide with a wrapper that forces software GL and X11
-    (lib.optional pkgs.stdenv.isLinux (pkgs.writeShellScriptBin "neovide" ''
-      #!/usr/bin/env bash
-      # Prefer software rendering in VMs; winit prefers X11 for broader compat
-      export LIBGL_ALWAYS_SOFTWARE="''${LIBGL_ALWAYS_SOFTWARE:-1}"
-      export MESA_LOADER_DRIVER_OVERRIDE="''${MESA_LOADER_DRIVER_OVERRIDE:-llvmpipe}"
-      if [ -n "''${DISPLAY-}" ]; then
-        export WINIT_UNIX_BACKEND="''${WINIT_UNIX_BACKEND:-x11}"
-      fi
-      exec ${pkgSet.neovide}/bin/neovide "$@"
-    ''))
-    # Convenience helper
-    (lib.optional pkgs.stdenv.isLinux (pkgs.writeShellScriptBin "neovide-soft" ''
-      #!/usr/bin/env bash
-      export LIBGL_ALWAYS_SOFTWARE=1
-      export MESA_LOADER_DRIVER_OVERRIDE=llvmpipe
-      export WINIT_UNIX_BACKEND=x11
-      exec ${pkgSet.neovide}/bin/neovide "$@"
-    ''))
-    (pkgs.writeShellScriptBin "svim" ''
-      #!/usr/bin/env bash
-      if [ $# -eq 0 ]; then
-        exec neovide --fork
-      else
-        exec neovide --fork "$@"
-      fi
-    '')
-  ];
+  home.packages = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux)
+    ([
+      pkgSet.neovide
+      (pkgs.writeShellScriptBin "svim" ''
+        #!/usr/bin/env bash
+        # On Linux, prefer software GL and X11 for compatibility
+        if [ "$(uname -s)" = "Linux" ]; then
+          export LIBGL_ALWAYS_SOFTWARE="''${LIBGL_ALWAYS_SOFTWARE:-1}"
+          export MESA_LOADER_DRIVER_OVERRIDE="''${MESA_LOADER_DRIVER_OVERRIDE:-llvmpipe}"
+          if [ -n "''${DISPLAY-}" ]; then
+            export WINIT_UNIX_BACKEND="''${WINIT_UNIX_BACKEND:-x11}"
+          fi
+        fi
+        if [ $# -eq 0 ]; then
+          exec ${pkgSet.neovide}/bin/neovide --fork
+        else
+          exec ${pkgSet.neovide}/bin/neovide --fork "$@"
+        fi
+      '')
+    ] ++ lib.optionals pkgs.stdenv.isLinux [
+      (pkgs.writeShellScriptBin "neovide-soft" ''
+        #!/usr/bin/env bash
+        export LIBGL_ALWAYS_SOFTWARE=1
+        export MESA_LOADER_DRIVER_OVERRIDE=llvmpipe
+        export WINIT_UNIX_BACKEND=x11
+        exec ${pkgSet.neovide}/bin/neovide "$@"
+      '')
+    ]);
 
   # Neovide config (XDG path)
   home.file.".config/neovide/config.toml" = lib.mkIf (pkgs.stdenv.isDarwin || pkgs.stdenv.isLinux) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -319,12 +319,20 @@ if [[ -x "$TARGET_SHELL" ]]; then
     if [[ "$PLATFORM" == "darwin" ]]; then
       sudo chsh -s "$TARGET_SHELL" "$USER" || warn "Could not change default shell automatically"
     else
-      chsh -s "$TARGET_SHELL" "$USER" || sudo chsh -s "$TARGET_SHELL" "$USER" || warn "Could not change default shell automatically"
+      chsh -s "$TARGET_SHELL" "$USER" \
+        || sudo chsh -s "$TARGET_SHELL" "$USER" \
+        || sudo usermod -s "$TARGET_SHELL" "$USER" \
+        || warn "Could not change default shell automatically"
     fi
   fi
   good "Default shell is set to $(basename "$TARGET_SHELL") (or already set)"
 else
   warn "Target shell not found/executable at $TARGET_SHELL — skipping default shell change"
+fi
+
+# Hint: $SHELL in the current process won't update automatically
+if [[ "${SHELL:-}" != "$TARGET_SHELL" ]]; then
+  warn "Current process shell remains $SHELL. Open a new terminal or run: exec \"$TARGET_SHELL\" -l"
 fi
 
 # =============== Finish ===============

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -294,6 +294,14 @@ fi
 HM_ZSH="$HOME/.local/state/nix/profiles/home-manager/home-path/bin/zsh"
 HM_BASH="$HOME/.local/state/nix/profiles/home-manager/home-path/bin/bash"
 
+# Ensure HM shells are registered in /etc/shells if present
+for _sh in "$HM_BASH" "$HM_ZSH"; do
+  if [[ -x "$_sh" ]] && ! grep -qxF "$_sh" /etc/shells; then
+    log "Registering $_sh in /etc/shells"
+    printf '%s\n' "$_sh" | sudo tee -a /etc/shells >/dev/null || true
+  fi
+done
+
 # Detect current login shell path
 if [[ "$PLATFORM" == "darwin" ]]; then
   CURRENT_SHELL_PATH=$(dscl . -read "/Users/$USER" UserShell 2>/dev/null | awk '{print $2}')

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -173,6 +173,36 @@ SNIP
 
 ensure_login_shell_env
 
+# =============== Purge conflicting dotfiles (pre-link cleanup) ===============
+# Home Manager refuses to clobber existing files it manages. Remove a small,
+# well-defined set of common dotfiles that this flake manages to avoid failures.
+purge_conflicting_dotfiles() {
+  log "Removing known conflicting dotfiles for Home Manager"
+  local targets=(
+    "$HOME/.profile"
+    "$HOME/.bashrc"
+    "$HOME/.bash_profile"
+    "$HOME/.bash_login"
+    "$HOME/.zshrc"
+    "$HOME/.zprofile"
+    "$HOME/.zlogin"
+    "$HOME/.config/gh/config.yml"
+  )
+  local removed=0
+  for t in "${targets[@]}"; do
+    if [ -e "$t" ] || [ -L "$t" ]; then
+      rm -f -- "$t" 2>/dev/null && echo "Removed: $t" && removed=1 || true
+    fi
+  done
+  if [ "$removed" -eq 1 ]; then
+    good "Removed conflicting dotfiles"
+  else
+    log "No conflicting dotfiles to remove"
+  fi
+}
+
+purge_conflicting_dotfiles
+
 # =============== Cleanup previous Home Manager backups (.backup) ===============
 # Some earlier runs may have created *.backup files that block activation when
 # using backup extensions. We proactively remove them.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -269,6 +269,16 @@ if [[ $APPLY_OK -ne 1 ]]; then
 fi
 good "Home Manager switch complete"
 
+# Load Home Manager session variables and ensure new tools are in PATH for this shell session
+HM_SESS_VARS="$HOME/.local/state/nix/profiles/home-manager/home-path/etc/profile.d/hm-session-vars.sh"
+if [[ -f "$HM_SESS_VARS" ]]; then
+  unset __HM_SESS_VARS_SOURCED
+  # shellcheck disable=SC1090
+  . "$HM_SESS_VARS"
+fi
+export PATH="$HOME/.local/state/nix/profiles/home-manager/home-path/bin:$PATH"
+hash -r || true
+
 # Commit flake.lock changes if updated during the switch (best-effort)
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   if [[ -n "$(git status --porcelain -- flake.lock)" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 # =============== Args ===============
 CUSTOM_INSTALL=0
+# Do not inject env snippet by default; Home Manager manages dotfiles
+APPLY_ENV_SNIPPET=${APPLY_ENV_SNIPPET:-0}
 usage() {
   cat <<'USAGE'
 Gentleman.Dots installer
@@ -231,7 +233,9 @@ cleanup_hm_backups() {
 cleanup_hm_backups
 
 # Now attempt environment snippet adjustments (best-effort)
-ensure_login_shell_env
+if [ "$APPLY_ENV_SNIPPET" -eq 1 ]; then
+  ensure_login_shell_env
+fi
 
 if command -v nix >/dev/null 2>&1; then
   good "Nix is already installed"

--- a/zsh.nix
+++ b/zsh.nix
@@ -137,6 +137,8 @@
       ${lib.optionalString pkgs.stdenv.isLinux ''
       # Ghostty wrapper for buggy EGL on some Linux VMs
       alias ghostty='GSK_RENDERER=cairo LIBGL_ALWAYS_SOFTWARE=1 ${pkgs.ghostty}/bin/ghostty'
+      # Neovide: prefer software GL and X11 on Linux VMs
+      alias neovide='LIBGL_ALWAYS_SOFTWARE=1 MESA_LOADER_DRIVER_OVERRIDE=llvmpipe WINIT_UNIX_BACKEND=x11 ${pkgs.neovide}/bin/neovide'
       ''}
     '';
   };

--- a/zsh.nix
+++ b/zsh.nix
@@ -133,6 +133,11 @@
       alias -- oo='oil .'
       alias -- oz=oil-zed
       alias -- opencode-config='nvim ~/.config/opencode/opencode.json'
+
+      ${lib.optionalString pkgs.stdenv.isLinux ''
+      # Ghostty wrapper for buggy EGL on some Linux VMs
+      alias ghostty='GSK_RENDERER=cairo LIBGL_ALWAYS_SOFTWARE=1 ${pkgs.ghostty}/bin/ghostty'
+      ''}
     '';
   };
 


### PR DESCRIPTION
[sudo] password for rudy: 
✔ Git is available
✔ Using existing checkout: /home/rudy/Gentleman.Dots
==> Removing known conflicting dotfiles for Home Manager
==> No conflicting dotfiles to remove
==> Scanning for old Home Manager backups (*.backup)
==> No .backup files found
✔ Nix is already installed
==> Ensuring /etc/nix/nix.conf has experimental features enabled
✔ Updated /etc/nix/nix.conf (flakes + nix-command)
==> Applying Home Manager configuration (flake: #gentleman-linux-arm)
✔ Personalized flake.nix for user 'rudy'
==> Committing flake.nix personalization
[feat/linux-support c4dc51b] installer: personalize flake.nix for user rudy
 1 file changed, 1 insertion(+), 1 deletion(-)
==> Applying Home Manager configuration (prefer nix run)
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'home-manager-generation'
         whose name attribute is located at /nix/store/9rfm3gjhphdvi7qnzdsi7piw1gi4c8vp-source/pkgs/stdenv/generic/make-derivation.nix:539:13

       … while evaluating attribute 'buildCommand' of derivation 'home-manager-generation'
         at /nix/store/9rfm3gjhphdvi7qnzdsi7piw1gi4c8vp-source/pkgs/build-support/trivial-builders/default.nix:80:17:
           79|         enableParallelBuilding = true;
           80|         inherit buildCommand name;
             |                 ^
           81|         passAsFile = [ "buildCommand" ] ++ (derivationArgs.passAsFile or [ ]);

       … while evaluating the option `home.activation.installPackages.data':

       … while evaluating definitions from `/nix/store/piwg5906lk80p5sd1x8g281slg20ygm1-source/modules/home-environment.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: A definition for option `home.packages."[definition 4-entry 2]"' is not of type `package'. Definition values:
       - In `/nix/store/r51dfym24y9lnclxgzx1p2adn9wcbfra-source/neovide.nix':
           [
             <derivation neovide>
           ]
⚠ nix run home-manager failed. Trying nix shell with home-manager.
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'home-manager-generation'
         whose name attribute is located at /nix/store/9rfm3gjhphdvi7qnzdsi7piw1gi4c8vp-source/pkgs/stdenv/generic/make-derivation.nix:539:13

       … while evaluating attribute 'buildCommand' of derivation 'home-manager-generation'
         at /nix/store/9rfm3gjhphdvi7qnzdsi7piw1gi4c8vp-source/pkgs/build-support/trivial-builders/default.nix:80:17:
           79|         enableParallelBuilding = true;
           80|         inherit buildCommand name;
             |                 ^
           81|         passAsFile = [ "buildCommand" ] ++ (derivationArgs.passAsFile or [ ]);

       … while evaluating the option `home.activation.installPackages.data':

       … while evaluating definitions from `/nix/store/piwg5906lk80p5sd1x8g281slg20ygm1-source/modules/home-environment.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: A definition for option `home.packages."[definition 4-entry 2]"' is not of type `package'. Definition values:
       - In `/nix/store/r51dfym24y9lnclxgzx1p2adn9wcbfra-source/neovide.nix':
           [
             <derivation neovide>
           ]
⚠ nix shell home-manager failed. Trying installed CLI if available.
==> Using local home-manager CLI
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'home-manager-generation'
         whose name attribute is located at /nix/store/9rfm3gjhphdvi7qnzdsi7piw1gi4c8vp-source/pkgs/stdenv/generic/make-derivation.nix:539:13

       … while evaluating attribute 'buildCommand' of derivation 'home-manager-generation'
         at /nix/store/9rfm3gjhphdvi7qnzdsi7piw1gi4c8vp-source/pkgs/build-support/trivial-builders/default.nix:80:17:
           79|         enableParallelBuilding = true;
           80|         inherit buildCommand name;
             |                 ^
           81|         passAsFile = [ "buildCommand" ] ++ (derivationArgs.passAsFile or [ ]);

       … while evaluating the option `home.activation.installPackages.data':

       … while evaluating definitions from `/nix/store/piwg5906lk80p5sd1x8g281slg20ygm1-source/modules/home-environment.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: A definition for option `home.packages."[definition 4-entry 2]"' is not of type `package'. Definition values:
       - In `/nix/store/r51dfym24y9lnclxgzx1p2adn9wcbfra-source/neovide.nix':
           [
             <derivation neovide>
           ]
✖ Home Manager switch failed. Ensure network access to fetch inputs or install the home-manager CLI.
bash-5.3$ 

